### PR TITLE
Add new `npm run prodwatch` command for testing dev JS against prod API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/dev-verify.min.js.map
 dist/prod-verify.js
 dist/verify.js
 dist/verify.js.map
+.idea

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ In your HTML, add:
 
 ```html
 
-<script src='https://cdn.goodforms.com/verify.js'></script>
+<script src='https://unpkg.com/goodforms@0.9.0'></script>
 ```
 
 Then run, near the bottom of your page:
@@ -54,18 +54,22 @@ Form submission will be prevented until the email field is marked as Valid.
 
 ## How to use from Require.JS (AMD)
 
+`npm install goodforms` should work, then you can just do: `var Goodforms = require('goodforms);` in 
+your .js code.
+
+Or you can try:
 ```js
-require(['https://cdn.goodforms.com/verify.js'], function (Goodforms) {
+requirejs(['https://unpkg.com/goodforms@0.9.0'], function (Goodforms) {
     Goodforms('form_key', {debug: true}) //use as normal
 });
 ```
 
 ## How to use as a Common.JS module
 
-Download the Verification Javascript from https://cdn.goodforms.com/verify.js , rename it to Goodforms, and then:
+run `npm install goodforms`, then:
 
 ```js
-var Goodforms = require('./Goodforms')
+var Goodforms = require('./goodforms')
 ```
 
 ## Debugging

--- a/package.json
+++ b/package.json
@@ -1,18 +1,17 @@
 {
   "name": "goodforms",
-  "version": "1.0.0",
+  "version": "0.9.0",
   "description": "Javascript to validate email addresses, optionally using the paid Goodforms service",
-  "main": "index.js",
-  "browser": "index.js",
-  "_notes": "does this mean we don't do main? I'm not sure. Can you include this in any other borwser-based project?",
+  "browser": "./dist/verify.js",
+  "exports": "./index.js",
+  "unpkg": "./dist/verify.js",
+  "files": ["/dist/verify.js", "/dist/verify.js.map", "/*.js", "/*.css", "/*.html"],
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "watch": "SERVERIP=$(ifconfig en0|grep 'inet '|cut -d ' ' -f 2); echo \"SERVERIP IS: $SERVERIP\"; rollup -c --watch --environment SNIPPET_ENV:dev --environment SERVERIP:$SERVERIP",
     "compress": "uglifyjs --source-map -o dist/dev-verify.min.js dist/dev-verify.js",
     "prodwatch": "SERVERNAME=https://api.goodforms.com rollup -c --watch --environment SNIPPET_ENV:production",
-    "production": "SERVERNAME=https://api.goodforms.com rollup -c --environment SNIPPET_ENV:production && uglifyjs --source-map \"url='https://cdn.goodforms.com/verify.js.map',content=inline\" -o dist/verify.js dist/prod-verify.js",
-    "publish": "aws --profile bespin s3 cp dist/ s3://cdn.goodverification.com/ --recursive --exclude '*' --include 'verify.js*'",
-    "purge": "aws --profile bespin cloudfront create-invalidation --distribution-id ENRJKUI04P9HN --paths '/*'"
+    "production": "SERVERNAME=https://api.goodforms.com rollup -c --environment SNIPPET_ENV:production && uglifyjs --source-map \"url='https://cdn.goodforms.com/verify.js.map',content=inline\" -o dist/verify.js dist/prod-verify.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Sometimes when you're developing the GF JS, you want to be able to work locally on the JS, but have it run against the production API endpoint. This allows you to do that with a new NPM subcommand.